### PR TITLE
added first draft adni.py

### DIFF
--- a/code/adni.py
+++ b/code/adni.py
@@ -20,9 +20,9 @@ from pathlib import Path
 
 # Define metadata
 metadata = {
-    "participant_id": {
-        "original_field_name": "Subject ID in adni_spreadsheet.csv (PTID in ADNIMERGE_22Aug2023.csv)",
-        "description": "Unique identifier for each participant",
+    "original_field_name": {
+        "adni_spreadsheet.csv": "Subject ID",
+        "ADNIMERGE_22Aug2023.csv": "PTID",
     },
     "age": {
         "original_field_name": "Age",

--- a/code/adni.py
+++ b/code/adni.py
@@ -6,7 +6,10 @@ All input stored in `data/adni` folder. The content of `data` is not
 included in the repository.
 
 The data is downloaded from https://adni.loni.usc.edu/. The data is not public, hence it is not included in this repository. See https://adni.loni.usc.edu/data-samples/access-data/
-for access instructions. Note: adni_spreadsheet.csv was handered over to me by Desiree, who was given it by Hanad. It lists the scanning data, but I am using a spreadsheet downloaded from ADNI directly for diagnoses.
+for access instructions.
+
+Note: adni_spreadsheet.csv was handered over to me by Desiree, who was given it by Hanad. It lists the scanning data, but I am using a spreadsheet downloaded from ADNI directly for
+diagnoses.
 
 """
 
@@ -36,17 +39,94 @@ metadata = {
         "levels": "unable to find the matching site names. Acquisition sites can be found here: https://adni.loni.usc.edu/about/centers-cores/study-sites/",
     },
     "diagnosis": {
-        "original_field_name": "",
+        "original_field_name": "DX in ADNIMERGE_22Aug2023.csv, or Research Group in adni_spreadsheet.csv",
         "description": "Diagnosis of the participant",
-        "levels": {},
+        "levels": {
+            "CON": "control",
+            "ADD": "Alzheimer's disease dementia",
+            "MCI": "mild cognitive impairment",
+            "Patient": "unknown",
+        },
     },
 }
 
 
+def find_closest_date(participant_df, scan_date):
+    # Compute the absolute difference in days between the scan date and diagnosis dates
+    participant_df["date_diff"] = (
+        participant_df["EXAMDATE"].sub(scan_date).dt.days.abs()
+    )
+
+    # Sort by date difference
+    participant_df.sort_values(by="date_diff", inplace=True)
+
+    # Filter for rows where DX is not blank, maintaining the order
+    valid_diagnosis_df = participant_df[
+        participant_df["DX"].notna() & (participant_df["DX"] != "")
+    ]
+
+    # Find the closest date with a valid diagnosis, if available
+    if not valid_diagnosis_df.empty:
+        closest_valid_diagnosis = valid_diagnosis_df.iloc[
+            0
+        ]  # First row is the closest with a valid DX
+        return (
+            closest_valid_diagnosis["DX"],
+            closest_valid_diagnosis["EXAMDATE"],
+            closest_valid_diagnosis["date_diff"],
+        )
+    else:
+        # Return None if no valid diagnosis is found
+        return None, None, None
+
+
+def find_closest_diagnosis(scan_row, diagnosis_df):
+    subject_id = scan_row["Subject ID"]
+    scan_date = scan_row["Study Date"]
+
+    # Filter to evaluations for the same participant where the evaluation date is not NULL
+    participant_df = diagnosis_df[
+        (diagnosis_df["PTID"] == subject_id) & diagnosis_df["EXAMDATE"].notna()
+    ].copy()
+
+    if not participant_df.empty:
+        return find_closest_date(participant_df, scan_date)
+    else:
+        # Return None if no matching participant entries were found
+        return None, None, None
+
+
+def process_diagnosis_data(scan_df, diagnosis_df):
+    # Apply function to match diagnoses according to closest scan date, and split the results into new columns
+    result = scan_df.apply(
+        lambda row: pd.Series(find_closest_diagnosis(row, diagnosis_df)), axis=1
+    )
+    scan_df[["diagnosis", "matched_evaluation_date", "date_diff"]] = (
+        result  # Returning these for now because at a later date we may want to drop e.g participants with diagnoses outside a certain window
+    )
+
+    # For those who only have screening visit, copy that diagnosis to column
+    scan_df.loc[scan_df["matched_evaluation_date"].isna(), "diagnosis"] = scan_df[
+        "Research Group"
+    ]
+
+    # Map values
+    scan_df["diagnosis"] = scan_df["diagnosis"].replace(
+        {"CN": "CON", "EMCI": "MCI", "LMCI": "MCI", "Dementia": "ADD"}
+    )
+
+    return scan_df
+
+
 def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
     # Load the CSVs
-    df = pd.read_csv(scan_file_p, index_col=0)
-    diagnosis_df = pd.read_csv(diagnosis_file_p, low_memory=False)
+    scan_df = pd.read_csv(scan_file_p, index_col=0, parse_dates=["Study Date"])
+    diagnosis_df = pd.read_csv(
+        diagnosis_file_p, low_memory=False, parse_dates=["EXAMDATE"]
+    )
+
+    # Match diagnoses
+    df = process_diagnosis_data(scan_df, diagnosis_df)
 
     # Process the data
     df["age"] = df["Age"].astype(float)
@@ -57,7 +137,7 @@ def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
     df["participant_id"] = df["Subject ID"].str.replace("_", "", regex=False)
 
     # Select columns
-    df = df[["participant_id", "age", "sex", "site"]]  # Diagnosis to be added
+    df = df[["participant_id", "age", "sex", "site", "diagnosis"]]
 
     # Sort df
     df = df.sort_values(by=["participant_id", "age"])

--- a/code/adni.py
+++ b/code/adni.py
@@ -116,7 +116,7 @@ def process_diagnosis_data(scan_df, diagnosis_df):
 
     # Map values
     scan_df["diagnosis"] = scan_df["diagnosis"].replace(
-        {"CN": "CON", "EMCI": "MCI", "LMCI": "MCI", "Dementia": "ADD"}
+        {"AD": "ADD", "CN": "CON", "EMCI": "MCI", "LMCI": "MCI", "Dementia": "ADD"}
     )
 
     return scan_df
@@ -167,6 +167,8 @@ def process_data(root_p, output_p, metadata):
     # Output metadata to json
     with open(output_p / "adni_pheno.json", "w") as f:
         json.dump(metadata, f, indent=2)
+
+    print(f"Data and metadata have been processed and output to {output_p}")
 
 
 if __name__ == "__main__":

--- a/code/adni.py
+++ b/code/adni.py
@@ -1,0 +1,83 @@
+"""Load ADNI data and extract demographic information.
+
+Author: Natasha Clarke; last edit 2024-02-23
+
+All input stored in `data/adni` folder. The content of `data` is not
+included in the repository.
+
+The data is downloaded from https://adni.loni.usc.edu/. The data is not public, hence it is not included in this repository. See https://adni.loni.usc.edu/data-samples/access-data/
+for access instructions. Note: adni_spreadsheet.csv was handered over to me by Desiree, who was given it by Hanad. It lists the scanning data, but I am using a spreadsheet downloaded from ADNI directly for diagnoses.
+
+"""
+
+import pandas as pd
+import json
+import argparse
+from pathlib import Path
+
+# Define metadata
+metadata = {
+    "participant_id": {
+        "original_field_name": "Subject ID in adni_spreadsheet.csv (PTID in ADNIMERGE_22Aug2023.csv)",
+        "description": "Unique identifier for each participant",
+    },
+    "age": {
+        "original_field_name": "Age",
+        "description": "Age of the participant in years",
+    },
+    "sex": {
+        "original_field_name": "Sex",
+        "description": "Sex of the participant",
+        "levels": {"male": "male", "female": "female"},
+    },
+    "site": {
+        "original_field_name": "Site is provided in the subject ID, e.g. for 011_S_0002 the site is 11",
+        "description": "Site of imaging data collection",
+        "levels": "unable to find the matching site names. Acquisition sites can be found here: https://adni.loni.usc.edu/about/centers-cores/study-sites/",
+    },
+    "diagnosis": {
+        "original_field_name": "",
+        "description": "Diagnosis of the participant",
+        "levels": {},
+    },
+}
+
+
+def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
+    # Load the CSVs
+    df = pd.read_csv(scan_file_p, index_col=0)
+    diagnosis_df = pd.read_csv(diagnosis_file_p, low_memory=False)
+
+    # Process the data
+    df["age"] = df["Age"].astype(float)
+    df["sex"] = df["Sex"].map({"F": "female", "M": "male"})
+    df["site"] = (
+        df["Subject ID"].str.split("_").str[0].str.lstrip("0")
+    )  # Extract site variable from ID and remove leading zeros
+    df["participant_id"] = df["Subject ID"].str.replace("_", "", regex=False)
+
+    # Select columns
+    df = df[["participant_id", "age", "sex", "site"]]  # Diagnosis to be added
+
+    # Sort df
+    df = df.sort_values(by="participant_id")
+
+    # Output tsv file
+    df.to_csv(output_p / "adni_pheno.tsv", sep="\t", index=False)
+
+    # Output metadata to json
+    with open(output_p / "adni_pheno.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Process ADNI phenotype data and output to to TSV and JSON"
+    )
+    parser.add_argument("scanfile", type=Path, help="Path to adni_spreadsheet.csv")
+    parser.add_argument("diagfile", type=Path, help="Path to ADNIMERGE_22Aug2023.csv")
+    parser.add_argument("output", type=Path, help="Path to the output directory")
+
+    args = parser.parse_args()
+
+    process_data(args.scanfile, args.diagfile, args.output, metadata)

--- a/code/adni.py
+++ b/code/adni.py
@@ -1,6 +1,6 @@
 """Load ADNI data and extract demographic information.
 
-Author: Natasha Clarke; last edit 2024-02-23
+Author: Natasha Clarke; last edit 2024-03-01
 
 All input stored in `data/adni` folder. The content of `data` is not
 included in the repository.

--- a/code/adni.py
+++ b/code/adni.py
@@ -60,7 +60,7 @@ def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
     df = df[["participant_id", "age", "sex", "site"]]  # Diagnosis to be added
 
     # Sort df
-    df = df.sort_values(by="participant_id")
+    df = df.sort_values(by=["participant_id", "age"])
 
     # Output tsv file
     df.to_csv(output_p / "adni_pheno.tsv", sep="\t", index=False)

--- a/code/adni.py
+++ b/code/adni.py
@@ -48,6 +48,10 @@ metadata = {
             "Patient": "unknown",
         },
     },
+    "educat": {
+        "original_field_name": "PTEDUCAT",
+        "description": "Years in education",
+    },
 }
 
 
@@ -128,6 +132,17 @@ def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
     # Match diagnoses
     df = process_diagnosis_data(scan_df, diagnosis_df)
 
+    # Get the education data
+    diagnosis_df = diagnosis_df.drop_duplicates(subset=["PTID"], keep="first")
+    df = pd.merge(
+        df,
+        diagnosis_df[["PTID", "PTEDUCAT"]],
+        left_on="Subject ID",
+        right_on="PTID",
+        how="left",
+    )
+    df.rename(columns={"PTEDUCAT": "educat"}, inplace=True)
+
     # Process the data
     df["age"] = df["Age"].astype(float)
     df["sex"] = df["Sex"].map({"F": "female", "M": "male"})
@@ -137,7 +152,7 @@ def process_data(scan_file_p, diagnosis_file_p, output_p, metadata):
     df["participant_id"] = df["Subject ID"].str.replace("_", "", regex=False)
 
     # Select columns
-    df = df[["participant_id", "age", "sex", "site", "diagnosis"]]
+    df = df[["participant_id", "age", "sex", "site", "diagnosis", "educat"]]
 
     # Sort df
     df = df.sort_values(by=["participant_id", "age"])

--- a/code/adni.py
+++ b/code/adni.py
@@ -1,6 +1,6 @@
 """Load ADNI data and extract demographic information.
 
-Author: Natasha Clarke; last edit 2024-03-01
+Author: Natasha Clarke; last edit 2024-03-04
 
 All input stored in `data/adni` folder. The content of `data` is not
 included in the repository.


### PR DESCRIPTION
Notes:

- Diagnosis to be added. Have written to Angela Tam to ask about this, there could be multiple ways.
- At the moment I have removed the underscores from the participant_id so that it matches the naming of the fMRI data (and therefore connectomes, qc etc). But for later matching with other ADNI variables etc it would be easier to leave them in...

UPDATE 
- Worked on diagnosis matching after discussion with Angela and looking at ADNI google group. I am taking diagnoses from ADNIMERGE, and using the nearest possible date to scanning date with a diagnosis to match. 

Notes
- The `Research Group` column provided in the adni_spreadsheet.csv must be from screening data, since EMCI and LMCI were only used at screening. According to the ANDI team, baseline visits or later yearly diagnostic
visits are more reliable diagnoses than screening (see discussion here https://groups.google.com/g/adni-data/c/whYhKafN_0Q, for example).
- Individuals with scanning data but no data in ADNIMERGE did not continue the study after screening, and so are also not in ADNI sheets like DXSUM_PDXCONV_ADNIALL. In that case I map remaining diagnoses from `Research Group` (i.e. screening). This includes `Patient`, which is not used anywhere by ADNI, so I would drop afterwards if diagnosis is important, since we don't know their true status.
- @htwangtw should all of this info go in the `json `file?